### PR TITLE
Moved to manual saves, bulk add / remove from packs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1889,7 +1889,7 @@ class MainWindow(QMainWindow):
             dialog.setIcon(QMessageBox.Icon.Warning)
             
             saveButton = dialog.addButton("Save All", QMessageBox.ButtonRole.AcceptRole)
-            discardButton = dialog.addButton("Discard Changes", QMessageBox.ButtonRole.DestructiveRole)
+            discardButton = dialog.addButton("Discard All", QMessageBox.ButtonRole.DestructiveRole)
             cancelButton = dialog.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
             
             dialog.exec()


### PR DESCRIPTION
The auto-save on exit feature has been removed in favour of a per-pack save button. Un-saved changes are tracked, and users are asked on exit to save or discard changes. Buttons have been added to enable bulk adding / removing of all selected mods to / from a pack. A link has been placed in the "workshop ID" to the workshop page of the selected mod.